### PR TITLE
RAD-5189 Delete Data Source Script

### DIFF
--- a/delete-data-source.js
+++ b/delete-data-source.js
@@ -1,0 +1,49 @@
+// Delete a group of data sources read from a csv file of the form:
+// id,xid
+const Files = Java.type('java.nio.file.Files');
+
+function readCsv(fileStore, filePath) {
+    const path = services.fileStoreService.getPathForRead(fileStore, filePath);
+    const lines = Files.readAllLines(path).toArray();
+    
+    const [headerLine, ...dataLines] = lines;
+    const header = headerLine.split(','); 
+    
+
+    const data = dataLines.map(line => {
+        const values = line.split(',');
+        return header.reduce((accumulator, key, index) => {
+            accumulator[key] = values[index];
+            return accumulator;
+        }, {});
+    });
+
+    return data;
+}
+
+const dataSourceService = services.dataSourceService;
+const dataSourceArray = readCsv('default', 'data-source-to-delete.csv');
+
+console.log(`Deleting ${dataSourceArray.length} data sources`);
+let count = 0;
+let failed = 0;
+for(const ds of dataSourceArray) {
+    try {
+        // Validations
+        dataSourceService.get(ds.xid);
+        dataSourceService.get(Number(ds.id));
+    
+        // Delete datasource
+        dataSourceService.delete(ds.xid);
+        count++;
+    } catch(error) {
+        console.log('Failed deleting data source', ds.xid, error.getMessage());
+        log.error('Failed deleting data source {}', ds.xid, error);
+        failed++;
+    }
+
+    if(count % 10 == 0){
+        console.log(`Deleted ${count} data sources out of ${dataSourceArray.length}`);
+    }
+}
+console.log(`Finished deleting ${count} out of ${dataSourceArray.length} data sources with ${failed} errors`);


### PR DESCRIPTION
## Description

[RAD-5189](https://radixiot.atlassian.net/browse/RAD-5189)
A script is being requested to have the ability to delete multiple data sources in mango.

A/C

When deleting a data source:

- Delete all data points on the data source
- Delete all events for all data points on the data source
- If points are published, they should be removed from the publisher
- Confirm if this will work while the publisher is running
- Remove event detectors before deleting data points
- Unlink event handlers before deleting event detectors

Script will require data source ID and XID

- Always validate 2 values before performing bulk delete operations

## Current behavior

No script with the ability to delete multiple data sources in mango.

## Expected behavior

Have a script with the ability to delete multiple data sources in mango.

## Changes

* Add script for delete data sources

## Resources

https://github.com/user-attachments/assets/7120c032-ece0-4fb2-9c98-5d889841e624


## Tests

* Manual testing



[RAD-5189]: https://radixiot.atlassian.net/browse/RAD-5189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ