### PR TITLE
feature/RAD-5597/add-samples-for-mariadb

### DIFF
--- a/event_detector_scripts/create-event-detectors.js
+++ b/event_detector_scripts/create-event-detectors.js
@@ -513,7 +513,11 @@ const message = handlersLinkDelimiter === ',' ? `INVALID DELIMITER. Please use a
 console.log(message);
 
 /*
-SELECT DISTINCT dP.id as dataPointId, dP.xid as dataPointXid, 
+
+ -- The following SQL query is suggested to create the CSV file for Mysql or MariaDB databases
+
+ SELECT DISTINCT dP.id as dataPointId,
+    dP.xid as dataPointXid,
     '' as detectorType, 
     '' as detectorName, 
     '' as alarmLevel, 
@@ -522,20 +526,55 @@ SELECT DISTINCT dP.id as dataPointId, dP.xid as dataPointXid,
     '' as stateInverted,
     0 as duration,
     'SECONDS' as durationType,
-    '' as handlers_to_link, dP.name as dataPointName,
+    '' as handlers_to_link,
+    dP.name as dataPointName,
     REPLACE(REPLACE(REPLACE(REPLACE(dP.dataTypeId, '1', 'BINARY'),
-       '2', 'MULTISTATE'), '3', 'NUMERIC'), '4',
-       'ALPHANUMERIC') as dataPointType,
-    dS.id as dataSourceId, dS.xid as dataSourceXid,
-    dS.name as dataSourceName, dS.dataSourceType
-FROM dataPoints dP
-INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
-WHERE
+        '2', 'MULTISTATE'), '3', 'NUMERIC'), '4','ALPHANUMERIC') as dataPointType,
+    dS.id as dataSourceId,
+    dS.xid as dataSourceXid,
+    dS.name as dataSourceName,
+    dS.dataSourceType
+ FROM dataPoints dP
+ INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
+ WHERE
     (
         dS.xid IN ('DS_b3dfc7fa-416e-4650-b8de-b521ce288275')
     )
-AND
+ AND
     (
         dP.name LIKE 'onOffAlarmPoint%'
-    )
+    );
+
+
+ -- Another example also for both databases(Mysql/MariaDB)
+
+ SELECT DISTINCT dP.id as dataPointId,
+    dP.xid as dataPointXid,
+	'' as detectorType,
+	'' as detectorName,
+	'' as alarmLevel,
+	'' as `limit`,
+	'' as stateValues,
+	'' as stateInverted,
+	0 as duration,
+    'SECONDS' as durationType,
+	'' as handlers_to_link,
+	dP.name as dataPointName,
+	REPLACE(REPLACE(REPLACE(REPLACE(dP.dataTypeId, '1', 'BINARY'),
+	    '2', 'MULTISTATE'), '3', 'NUMERIC'),'4', 'ALPHANUMERIC') as dataPointType,
+	dS.id as dataSourceId,
+	dS.xid as dataSourceXid,
+	dS.name as dataSourceName,
+	dS.dataSourceType
+ FROM  dataPoints dP
+ INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
+ WHERE
+      (
+          dS.xid IN ('DS_df8c0162-9bce-4980-9160-7791d5d558aa')
+      )
+ AND
+      (
+          dP.name LIKE '%Voltage%'
+      );
+
 */

--- a/event_detector_scripts/delete-event-detectors.js
+++ b/event_detector_scripts/delete-event-detectors.js
@@ -118,26 +118,66 @@ for (const eventDetectorCsv of eventDetectorsArray) {
 console.log(`Finished deleting ${count} out of ${eventDetectorsArray.length} event detectors with ${failed} errors`);
 
 /*
-Example to create the CSV file from an SQL query
-SELECT eD.id as eventDetectorId, eD.xid as eventDetectorXid, 
-    dP.id as dataPointId, dP.xid as dataPointXid, 
-    eD.sourceTypeName as detectorsourceTypeName,  eD.TypeName as detectorTypeName, 
-    '' as `limit`, '' as alarmLevel, 
-    dP.name as dataPointName, dS.id as dataSourceId,
-    dS.xid as dataSourceXid, dS.name as dataSourceName, dS.dataSourceType,
+Example to create the CSV file from an SQL query for Mysql/MariaDB database
+
+ SELECT eD.id as eventDetectorId,
+    eD.xid as eventDetectorXid,
+    dP.id as dataPointId,
+    dP.xid as dataPointXid,
+    eD.sourceTypeName as detectorSourceTypeName,
+    eD.TypeName as detectorTypeName,
+    '' as `limit`,
+    '' as alarmLevel,
+    dP.name as dataPointName,
+    dS.id as dataSourceId,
+    dS.xid as dataSourceXid,
+    dS.name as dataSourceName,
+    dS.dataSourceType,
     eD.data as detectorData
-FROM eventDetectors eD
-INNER JOIN dataPoints dP ON eD.dataPointId = dP.id
-INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
-WHERE
+ FROM eventDetectors eD
+ INNER JOIN dataPoints dP ON eD.dataPointId = dP.id
+ INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
+ WHERE
     (
         dS.id IN (63, 65, 69)
         OR
         dS.xid IN ('internal_mango_monitoring_ds')
     )
-AND
+ AND
     (
         dP.name LIKE 'JVM%'
+    );
+
+
+
+ -- Another example also for both databases(Mysql/MariaDB)
+
+ SELECT eD.id as eventDetectorId,
+    eD.xid as eventDetectorXid,
+    dP.id as dataPointId,
+    dP.xid as dataPointXid,
+    eD.sourceTypeName as detectorSourceTypeName,
+    eD.TypeName as detectorTypeName,
+    '' as `limit`,
+    '' as alarmLevel,
+    dP.name as dataPointName,
+    dS.id as dataSourceId,
+    dS.xid as dataSourceXid,
+    dS.name as dataSourceName,
+    dS.dataSourceType,
+    eD.data as detectorData
+ FROM eventDetectors eD
+ INNER JOIN dataPoints dP ON eD.dataPointId = dP.id
+ INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
+ WHERE
+    (
+        dS.id IN (297390)
+        OR
+        dS.xid IN ('DS_df8c0162-9bce-4980-9160-7791d5d558aa')
+    )
+ AND
+    (
+        dP.name LIKE '%Voltage%'
     );
 
 */

--- a/event_detector_scripts/edit-event-detectors.js
+++ b/event_detector_scripts/edit-event-detectors.js
@@ -422,16 +422,23 @@ const message = handlersLinkDelimiter === ',' ? `INVALID DELIMITER. Please use a
 console.log(message);
 
 /**
- Example to create the CSV file from an MySQL SQL query
-SELECT DISTINCT eD.id as eventDetectorId, eD.xid as eventDetectorXid, eD.typeName as detectorType,
-    '' as newDetectorName, '' as newAlarmLevel, '' as newLimit, '' as newStateValues,
+
+ -- Example to create the CSV file from an MySQL SQL query:
+
+ SELECT DISTINCT eD.id as eventDetectorId,
+    eD.xid as eventDetectorXid,
+    eD.typeName as detectorType,
+    '' as newDetectorName,
+    '' as newAlarmLevel,
+    '' as newLimit,
+    '' as newStateValues,
     '' as newStateInverted,
     '' as newDuration,
     '' as newDurationType,
     '' as handlers_to_link,
     '' as handlers_to_remove,
-    REPLACE(REPLACE(REPLACE(REPLACE(dP.dataTypeId, '1', 'BINARY'), '2', 'MULTISTATE'), '3',
-        'NUMERIC'), '4','ALPHANUMERIC') as dataPointType,
+    REPLACE(REPLACE(REPLACE(REPLACE(dP.dataTypeId, '1','BINARY'),
+        '2', 'MULTISTATE'), '3','NUMERIC'), '4','ALPHANUMERIC') as dataPointType,
     eD.data->>'$.name' as existingName,
     eD.data->>'$.alarmLevel' as existingAlarmLevel,
     eD.data->>'$.limit' as existingLimit,
@@ -441,35 +448,103 @@ SELECT DISTINCT eD.id as eventDetectorId, eD.xid as eventDetectorXid, eD.typeNam
         WHEN eD.data->>'$.states' = 'null' THEN eD.data->>'$.state'
         ELSE REPLACE(REPLACE(REPLACE(eD.data->>'$.states', '[', ''), ']', ''), ',', ';')
     END as existingStateValues,
-    eD.data->>'$.inverted' as existingStateInverted, dP.name as dataPointName,
+    eD.data->>'$.inverted' as existingStateInverted,
+    dP.name as dataPointName,
     eD.data->>'$.sourceType' as detectorSourceType,
-    dP.id as dataPointId, dP.xid as dataPointXid, dS.id as dataSourceId, dS.xid as dataSourceXid,
-    dS.name as dataSourceName, dS.dataSourceType
-FROM eventDetectors eD
-INNER JOIN dataPoints dP ON eD.dataPointId = dP.id
-INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
-WHERE
+    dP.id as dataPointId,
+    dP.xid as dataPointXid,
+    dS.id as dataSourceId,
+    dS.xid as dataSourceXid,
+    dS.name as dataSourceName,
+    dS.dataSourceType
+ FROM eventDetectors eD
+ INNER JOIN dataPoints dP ON eD.dataPointId = dP.id
+ INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
+ WHERE
     (
         eD.data->>'$.sourceType' IN ('DATA_POINT')
     )
-AND
+ AND
     (
         dS.id IN (63, 65, 69)
         OR
         dS.xid IN ('DS_b3dfc7fa-416e-4650-b8de-b521ce288275')
     )
-AND
+ AND
     (
         eD.typeName IN ('HIGH_LIMIT', 'LOW_LIMIT', 'BINARY_STATE', 'MULTISTATE_STATE')
     )
-AND
+ AND
     (
         dP.name LIKE 'onOffAlarmPoint%'
     )
-AND
+ AND
     (
         eD.data->>'$.name' LIKE 'Weather%'
         OR
         eD.data->>'$.name' LIKE 'weather%'
+    );
+
+ -- Example SQL query to create the CSV file on MariaDB:
+
+ SELECT DISTINCT eD.id as eventDetectorId,
+    eD.xid as eventDetectorXid,
+    eD.typeName as detectorType,
+    '' as newDetectorName,
+    '' as newAlarmLevel,
+    '' as newLimit,
+    '' as newStateValues,
+    '' as newStateInverted,
+    '' as newDuration,
+    '' as newDurationType,
+    '' as handlers_to_link,
+    '' as handlers_to_remove,
+    REPLACE(REPLACE(REPLACE(REPLACE(dP.dataTypeId,'1', 'BINARY'),
+        '2', 'MULTISTATE'),'3', 'NUMERIC'),'4', 'ALPHANUMERIC') as dataPointType,
+    JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.name')) as existingName,
+    JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.alarmLevel')) as existingAlarmLevel,
+    JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.limit')) as existingLimit,
+    JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.duration')) as existingDuration,
+    CASE
+        WHEN (JSON_EXTRACT(eD.data, '$.states') is null or JSON_EXTRACT(eD.data, '$.states') = 'null')
+            THEN JSON_EXTRACT(eD.data, '$.state')
+        ELSE REPLACE(REPLACE(REPLACE(JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.states')), '[', ''), ']', ''), ',', ';')
+    END as existingStateValues,
+    JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.inverted')) as existingStateInverted,
+    dP.name as dataPointName,
+    JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.sourceType')) as detectorSourceType,
+    dP.id as dataPointId,
+    dP.xid as dataPointXid,
+    dS.id as dataSourceId,
+    dS.xid as dataSourceXid,
+    dS.name as dataSourceName,
+    dS.dataSourceType
+ FROM eventDetectors eD
+ INNER JOIN dataPoints dP ON eD.dataPointId = dP.id
+ INNER JOIN dataSources dS ON dP.dataSourceId = dS.id
+ WHERE
+    (
+        JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.sourceType')) IN ('DATA_POINT')
     )
+ AND
+    (
+        dS.id IN (11)
+        OR
+        dS.xid IN ('DS_df8c0162-9bce-4980-9160-7791d5d558aa')
+    )
+ AND
+    (
+        eD.typeName IN ('MULTISTATE_STATE')
+    )
+ AND
+    (
+        dP.name LIKE '%Voltage%'
+    )
+ AND
+    (
+        JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.name')) LIKE 'Output%'
+        OR
+        JSON_UNQUOTE(JSON_EXTRACT(eD.data, '$.name')) LIKE '%Low'
+    );
+
  */


### PR DESCRIPTION
RAD-5597 add samples for mariadb event detectors scripts usage

I ordered existing queries to show one column per line so it would be easier to compare or to identified the columns involved.

Just the **edit-event-detectors.js** query needed to be modified to work on MariaDB and the changes are:
1  Convert the text data from text to json
2 Exctract the property value
3 Delete quotes **"**value**"**

As queries for create-event-detectors.js and delete-event-detectors.js work in MySQL and MariaDB I added a commend that mention that and I added another query example.

**create-event-detectors.js** query working on MariaDB

<img width="1792" alt="Screenshot 2024-08-14 at 10 35 40 a m" src="https://github.com/user-attachments/assets/4e0cf2af-bcec-4c1d-8f8c-caa5c9d50ed3">



**edit-event-detectors.js** query working on MariaDB

<img width="1792" alt="Screenshot 2024-08-14 at 10 36 05 a m" src="https://github.com/user-attachments/assets/79de7df9-8d9a-438b-8563-b41034d3adef">



**delete-event-detectors.js** query working on MariaDB

<img width="1792" alt="Screenshot 2024-08-14 at 10 36 50 a m" src="https://github.com/user-attachments/assets/9cacaac4-44bf-4cff-b24f-cbe68ff498a8">

I have also addressed Joe's commend about a couple of **typos** that mentioned in the ticket RAD-5597