### PR TITLE
[RAD-5686] Event Detector scripts - Add Change, Range, and Reset Limit options

### DIFF
--- a/event_detector_scripts/create-event-detectors.js
+++ b/event_detector_scripts/create-event-detectors.js
@@ -396,6 +396,10 @@ for (const eventDetectorCsv of eventDetectorsArray) {
             try {
                 assureNotEmpty('resetLimit', eventDetectorCsv.resetLimit);
                 if (Number.isNaN(Number.parseFloat(eventDetectorCsv.resetLimit))) {
+                    log.error('resetLimit {}: Not Supported!', eventDetectorCsv.resetLimit);
+                    verbose(`resetLimit ${eventDetectorCsv.resetLimit}: Not Supported!`);
+                    insertED = false;
+                    failed++;
                     throw new Error(`resetLimit ${eventDetectorCsv.resetLimit}: Not Supported!`)
                 }
                 else
@@ -422,8 +426,7 @@ for (const eventDetectorCsv of eventDetectorsArray) {
     let hasHighRangeLimit = false;
     //Validate RANGE detectors
     if (eventDetectorCsv.detectorType === 'RANGE') {
-        // TODO confirm that
-        //Do not allow MULTISTATE or BINARY points to use LIMIT detectors
+        //Do not allow MULTISTATE or BINARY points to use RANGE detectors
         if (['MULTISTATE', 'BINARY'].includes(eventDetectorCsv.dataPointType)) {
             //This type of point cannot use this type of detector
             log.error(`Detector Type ${eventDetectorCsv.detectorType} not supported for Point Type ${eventDetectorCsv.dataPointType} on Point XID ${eventDetectorCsv.dataPointXid}.`);
@@ -656,9 +659,9 @@ console.log(message);
     '' as alarmLevel, 
     '' as `limit`,
     '' as `resetLimit`,
-	  '' as `lowRangeLimit`,
-	  '' as `highRangeLimit`,
-	  '' as `withinRange`,
+    '' as `lowRangeLimit`,
+    '' as `highRangeLimit`,
+    '' as `withinRange`,
     '' as stateValues, 
     '' as stateInverted,
     0 as duration,
@@ -736,9 +739,9 @@ console.log(message);
     '' as alarmLevel,
     '' as `limit`,
     '' as `resetLimit`,
-	  '' as `lowRangeLimit`,
-	  '' as `highRangeLimit`,
-	  '' as `withinRange`,
+    '' as `lowRangeLimit`,
+    '' as `highRangeLimit`,
+    '' as `withinRange`,
     '' as stateValues,
     '' as stateInverted,
     0 as duration,


### PR DESCRIPTION
## Description

[RAD-5686](https://radixiot.atlassian.net/browse/RAD-5686)
Requesting support for Change and Range Event Detector types to be included in the Create, Edit and Delete Event Detector scripts. 
* Change - Event Detector 
* Range - Event Detector 

Also add selection for Use reset limit and Reset limit value for Low Limit and High Limit event detector types. 
* High Limit - Event Detector 
* Low Limit - Event Detector 

A/C

* Ability to use Change event detector type in scripts
* Ability to use Range event detector type in scripts
* Expand usage of Low and High Limit to include use of Use reset limit 
* Update queries for Create, Edit and Delete accordingly

## Current behavior

- No Ability to use Change and Range event detector type in scripts
- No usage of Low and High Limit to include use of Use reset limit 

## Expected behavior

- Ability to use Change and Range event detector type in scripts
- Expand usage of Low and High Limit to include use of Use reset limit 

## Changes

* Update create event detector script to add change, range and reset limit options
* Update edit event detector script to add change, range and reset limit options

## Resources
1. Create event detectors

https://github.com/user-attachments/assets/597118d8-1f44-4307-9b33-361231fc8534

2. Create event detector validations

https://github.com/user-attachments/assets/a79e200f-c23a-4158-9365-bd164469cd3c

3. Edit event detectors

https://github.com/user-attachments/assets/f2cde832-50c7-45c1-9be0-c9d297ca4a62

4. Edit event detectors validations

https://github.com/user-attachments/assets/262cd477-97bb-4f97-af9a-ef87a7b78d7b


## Tests

* Manual testing



[RAD-5686]: https://radixiot.atlassian.net/browse/RAD-5686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ