### PR TITLE
[RAD-5674] Creating a script to change the Role XID’s

### DIFF
--- a/change-role-xid.js
+++ b/change-role-xid.js
@@ -1,0 +1,46 @@
+/**
+ * This script replaces spaces on XID for underscore for roles
+ * Was tested MANGO 4.5.X
+ * Last update Mar 2025
+ * 
+ * This steps are:
+ * 1. Get all roles
+ * 2. Check if the XID has space
+ * 3. Replace spaces with underscore on XID
+ * 4. Update role
+ */
+
+// imports
+const Common = Java.type('com.serotonin.m2m2.Common');
+const RoleVO = Java.type('com.serotonin.m2m2.vo.role.RoleVO');
+const RoleDao = Java.type('com.serotonin.m2m2.db.dao.RoleDao');
+
+const roleDao = Common.getBean(RoleDao.class);
+const roleService = services.roleService;
+
+// Function to check if a string contains a space
+function hasSpace(xid) {
+    return xid.includes(' ');
+}
+
+// Get roles
+var roles = roleService.list();
+var rolesUpdated = 0;
+if (roles) {
+    for (var i = 0; i < roles.length; i++) {
+        var obj = roles[i];
+        var xid = obj.getXid();
+
+        // update role if XID has spaces
+        if (hasSpace(xid)) {
+            const nameWithoutSpace = xid.replace(' ','_');
+            const updated = new RoleVO(obj.getId(), nameWithoutSpace, obj.getName());
+            roleDao.update(obj.getId(), updated);
+            console.log('Rol updated with XID: ', xid);
+            rolesUpdated++;
+        }
+    }
+} else {
+    console.log("List of roles is undefined or null.");
+}
+console.log('Roles updated:', rolesUpdated);


### PR DESCRIPTION
## Description

[RAD-5674](https://radixiot.atlassian.net/browse/RAD-5674)
The issue involves creating a script to change Role XIDs in the Stallion Prod/Dev systems due to an error preventing the modification of these XIDs.

A/C

* The script should correct Role XIDs containing a space with a hyphen or underscore.
* Data linked to the changed XIDs must maintain their connection to the updated Roles.

## Current behavior

- Role XID has spaces

## Expected behavior

- Role XID without spaces

## Changes

* create script to update role XID

## Resources
<img width="1025" alt="Captura de pantalla 2025-03-05 a la(s) 10 38 31 a  m" src="https://github.com/user-attachments/assets/31c0ccfd-2e25-4d49-ba62-87f690b06d5d" />

<img width="481" alt="Captura de pantalla 2025-03-05 a la(s) 10 40 34 a  m" src="https://github.com/user-attachments/assets/c0ea009b-d91f-421a-8dab-0024755b8afc" />


## Tests

* Manual testing


[RAD-5674]: https://radixiot.atlassian.net/browse/RAD-5674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ