### PR TITLE
Script created for service ticket #54822.

### DIFF
--- a/v4_generatePublisherJsonFromUnpublishedPoints.js
+++ b/v4_generatePublisherJsonFromUnpublishedPoints.js
@@ -1,0 +1,77 @@
+/*
+ * Tested on MANGO 4.5.x
+ * Last update Jun 2025
+ * Version 1.0
+================================================================================
+  HOW TO GENERATE THE INITIAL CSV OF UNPUBLISHED DATA POINTS
+
+  1. Go to Mango's SQL Console (Admin > SQL Console).
+  2. Run the following query to get all data points that are NOT published:
+
+     SELECT dp.id, dp.xid, dp.name, dp.deviceName
+     FROM dataPoints dp
+     WHERE dp.id NOT IN (SELECT pp.dataPointId FROM publishedPoints pp)
+     ORDER BY dp.deviceName, dp.name
+
+  3. Download the query results as a CSV file.
+     - Make sure the CSV columns are: id, xid, name, deviceName (You will be reqired to remove "A" column. 
+
+  4. Upload the CSV file to the Mango Default Filestore.
+     - Example filename: your-query-output.csv
+
+  5. Add or remove publisher XID's that you will want to distrubte the points that are not currenly being published. Note: You may also want to create new publishers for currently running publishers do not need to reindex. 
+  
+  6. Set the 'filePath' variable in this script to match your uploaded CSV filename.
+
+================================================================================
+*/
+
+const Files = Java.type('java.nio.file.Files');
+
+// CONFIGURE THESE:
+const fileStore = 'default';
+const filePath = 'your-query-output.csv'; // Your CSV file name
+const publisherXids = ['PUB_AAA-1', 'BBB-2', 'PUB_CCC-3']; // Add/remove as needed
+const enabledValue = true;
+
+// Read CSV
+function readCsv(fileStore, filePath) {
+    const path = services.fileStoreService.getPathForRead(fileStore, filePath);
+    const lines = Array.from(Files.readAllLines(path));
+    const header = lines.shift().split(',');
+    const rows = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (!lines[i].trim()) continue; // skip empty lines
+        const row = lines[i].split(',');
+        const data = {};
+        for (let j = 0; j < row.length; j++) {
+            data[header[j].trim()] = row[j].trim();
+        }
+        rows.push(data);
+    }
+    return rows;
+}
+
+// Main logic
+const pointsArray = readCsv(fileStore, filePath);
+const publisherCount = publisherXids.length;
+let assignIndex = 0;
+const publishedPoints = [];
+
+for (const point of pointsArray) {
+    // Assign publisher in round-robin fashion
+    const publisherXid = publisherXids[assignIndex % publisherCount];
+    assignIndex++;
+    publishedPoints.push({
+        name: point.name,
+        dataPointXid: point.xid,
+        publisherXid: publisherXid,
+        enabled: enabledValue
+    });
+}
+
+const output = {
+    publishedPoints: publishedPoints
+};
+
+print(JSON.stringify(output, null, 4));

--- a/v4_generatePublisherJsonFromUnpublishedPoints.js
+++ b/v4_generatePublisherJsonFromUnpublishedPoints.js
@@ -1,30 +1,34 @@
+
 /*
  * Tested on MANGO 4.5.x
- * Last update Jun 2025
- * Version 1.0
-================================================================================
-  HOW TO GENERATE THE INITIAL CSV OF UNPUBLISHED DATA POINTS
+ * Last updated: June 2025
+ * Version: 1.0
+ ================================================================================
+   HOW TO GENERATE THE INITIAL CSV OF UNPUBLISHED DATA POINTS
 
-  1. Go to Mango's SQL Console (Admin > SQL Console).
-  2. Run the following query to get all data points that are NOT published:
+   1. Go to Mango's SQL Console (Admin > SQL Console).
+   2. Run the following query to retrieve all data points that are NOT published:
 
-     SELECT dp.id, dp.xid, dp.name, dp.deviceName
-     FROM dataPoints dp
-     WHERE dp.id NOT IN (SELECT pp.dataPointId FROM publishedPoints pp)
-     ORDER BY dp.deviceName, dp.name
+      SELECT dp.id, dp.xid, dp.name, dp.deviceName
+      FROM dataPoints dp
+      WHERE dp.id NOT IN (SELECT pp.dataPointId FROM publishedPoints pp)
+      ORDER BY dp.deviceName, dp.name;
 
-  3. Download the query results as a CSV file.
-     - Make sure the CSV columns are: id, xid, name, deviceName (You will be reqired to remove "A" column. 
+   3. Download the query results as a CSV file.
+      - Ensure the CSV columns are: id, xid, name, deviceName.
+      - You will need to remove the "A" column if it appears.
 
-  4. Upload the CSV file to the Mango Default Filestore.
-     - Example filename: your-query-output.csv
+   4. Upload the CSV file to the Mango Default Filestore.
+      - Example filename: your-query-output.csv
 
-  5. Add or remove publisher XID's that you will want to distrubte the points that are not currenly being published. Note: You may also want to create new publishers for currently running publishers do not need to reindex. 
-  
-  6. Set the 'filePath' variable in this script to match your uploaded CSV filename.
+   5. Add or remove publisher XIDs for distributing the unpublished points.
+      - Note: You may also want to create new publishers if the currently running ones do not need to reindex.
 
-================================================================================
+   6. Set the 'filePath' variable in this script to match your uploaded CSV filename.
+
+ ================================================================================
 */
+
 
 const Files = Java.type('java.nio.file.Files');
 


### PR DESCRIPTION
**Overview**
This Mango Automation script automates the process of assigning unpublished data points to one or more publishers. It is designed to help system administrators efficiently distribute data points that are not currently published, by generating a JSON configuration that can be used for bulk publishing or further automation.

**Features**
Reads a CSV file of unpublished data points exported from Mango’s SQL Console.

Evenly distributes data points among a configurable list of publisher XIDs.

Outputs a JSON object suitable for import or further processing.

Customizable publisher list—easily add or remove publisher XIDs as needed.

Clear setup instructions included in the script comments.

**Use Cases**
Quickly assign new or unassigned data points to publishers in bulk.

Prepare JSON configurations for automated publisher setup.

Streamline onboarding of new devices or data sources.

**Prerequisites**
Access to Mango Automation’s SQL Console and Filestore.

Sufficient permissions to run scripts and manage publishers/data points.

**Setup Instructions**
Export Unpublished Data Points:

Use the provided SQL query in Mango’s SQL Console to export all data points not currently published.

Download the results as a CSV file and ensure the columns are: id, xid, name, deviceName.

Remove any extra columns (such as the "A" column) if present.

**Upload the CSV:**

Place the CSV file in Mango’s Default Filestore.

**Configure the Script:**

Edit the publisherXids array in the script to include the XIDs of the publishers you want to use.

Set the filePath variable to match your uploaded CSV filename.

**Run the Script:**

Execute the script in Mango’s scripting environment.

The script will output a JSON object with the unpublished points assigned to publishers.

**Example SQL Query**


SELECT dp.id, dp.xid, dp.name, dp.deviceName
FROM dataPoints dp
WHERE dp.id NOT IN (SELECT pp.dataPointId FROM publishedPoints pp) ORDER BY dp.deviceName, dp.name

**Notes**
You may want to create new publishers if you do not want to reindex currently running publishers.

The script can be easily modified to assign each point to multiple publishers if needed.