### PR TITLE
[RAD-5939] Scripting Data Source to track Mango, Modules, and OS details

### DIFF
--- a/track-mango-details.js
+++ b/track-mango-details.js
@@ -1,0 +1,82 @@
+/**
+ * Script to track Mango, Modules, and OS details
+ * Last update Sept 2025
+ *
+ * Java Details
+ * - Java version
+ *
+ * Mango Details
+ * - Mango Version
+ * - UDMI Version
+ *
+ * OS Details
+ * - OS Type
+ * - OS Release
+ * - OS Distributor
+ *
+ * Note: For OS linux is necessary install lsb_release
+ */
+
+var Runtime = Java.type('java.lang.Runtime');
+var System = Java.type('java.lang.System');
+var ModuleRegistry = Java.type('com.serotonin.m2m2.module.ModuleRegistry');
+var InputStreamReader = Java.type('java.io.InputStreamReader');
+var BufferedReader = Java.type('java.io.BufferedReader');
+
+var mango_version = ModuleRegistry.getModule("core").getVersion();
+LOG.debug("Mango Version: " + mango_version);
+var_mango_version.set(mango_version);
+
+var udmi_version = ModuleRegistry.getModule("udmi").getVersion();
+LOG.debug("UDMI Version: " + udmi_version);
+var_udmi_version.set(udmi_version);
+
+var java_version = System.getProperty('java.version').toString();
+LOG.debug("Java Version: " + java_version)
+var_java_version.set(java_version);
+
+var os_type = System.getProperty('os.name').toString();
+var os_release = "";
+var os_distributor = "";
+LOG.debug("OS Type: " + os_type);
+var_os_type.set(os_type);
+
+//OS Type (Windows/Linux/etc.)
+if (os_type == 'Linux') {
+  var rt = Runtime.getRuntime();
+
+  try {
+    runCommand('lsb_release -a');
+  } catch (err) {
+    LOG.debug(err.message);
+  }
+}
+
+LOG.debug("OS Release: " + os_release);
+var_os_release.set(os_release);
+
+LOG.debug("OS Distributor: " + os_distributor);
+var_os_distributor.set(os_distributor);
+
+function runCommand(commandString) {
+  LOG.debug('Executing command: ' + commandString);
+  var process = rt.exec(commandString);
+  var inputStreamReader = new InputStreamReader(process.getInputStream());
+  var bufferedReader = new BufferedReader(inputStreamReader);
+  var line;
+  while ((line = bufferedReader.readLine()) != null) {
+    var lineParts = line.split(':');
+    switch (lineParts[0].trim().toUpperCase()) {
+      case 'DISTRIBUTOR ID':
+        os_release = lineParts[1].trim();
+        break;
+      case 'RELEASE':
+        os_distributor = lineParts[1].trim();
+        break;
+      default:
+        continue;
+    }
+  }
+  var exitCode = process.waitFor();
+  return exitCode.toString();
+}

--- a/track-mango-details.js
+++ b/track-mango-details.js
@@ -23,60 +23,110 @@ var ModuleRegistry = Java.type('com.serotonin.m2m2.module.ModuleRegistry');
 var InputStreamReader = Java.type('java.io.InputStreamReader');
 var BufferedReader = Java.type('java.io.BufferedReader');
 
-var mango_version = ModuleRegistry.getModule("core").getVersion();
-LOG.debug("Mango Version: " + mango_version);
-var_mango_version.set(mango_version);
+// --- HELPER FUNCTIONS ---
 
-var udmi_version = ModuleRegistry.getModule("udmi").getVersion();
-LOG.debug("UDMI Version: " + udmi_version);
-var_udmi_version.set(udmi_version);
+/**
+ * Gets the version of a Mango module by name.
+ * @param {string} moduleName - The name of the module (e.g., "core", "udmi").
+ * @returns {string} The module version or "ERROR" if it fails.
+ */
+function getModuleVersion(moduleName) {
+  try {
+    var version = ModuleRegistry.getModule(moduleName).getVersion();
+    LOG.debug("Module version '" + moduleName + "': " + version);
+    return version;
+  } catch (e) {
+    LOG.error("Failed to get module version for '" + moduleName + "': " + e.message);
+    return 'ERROR';
+  }
+}
 
-var java_version = System.getProperty('java.version').toString();
-LOG.debug("Java Version: " + java_version)
-var_java_version.set(java_version);
+/**
+ * Gets a system property.
+ * @param {string} propertyName - The name of the property (e.g., "java.version").
+ * @returns {string} The property value or "ERROR" if it fails.
+ */
+function getSystemProperty(propertyName) {
+  try {
+    var propertyValue = System.getProperty(propertyName).toString();
+    LOG.debug("System property '" + propertyName + "': " + propertyValue);
+    return propertyValue;
+  } catch (e) {
+    LOG.error("Failed to get system property '" + propertyName + "': " + e.message);
+    return 'ERROR';
+  }
+}
 
-var os_type = System.getProperty('os.name').toString();
-var os_release = "";
-var os_distributor = "";
-LOG.debug("OS Type: " + os_type);
-var_os_type.set(os_type);
+/**
+ * Executes a system shell command and returns its output.
+ * @param {string} command - The command to execute.
+ * @returns {string[] | null} An array with the output lines, or null on error.
+ */
+function runCommand(command) {
+  LOG.debug("Executing command: " + command);
+  try {
+    var process = Runtime.getRuntime().exec(command);
+    var reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+    var lines = [];
+    var line;
+    while ((line = reader.readLine()) !== null) {
+      lines.push(line);
+    }
+
+    var exitCode = process.waitFor();
+    LOG.debug("Command finished with exit code: " + exitCode);
+
+    if (exitCode !== 0) {
+      throw new Error("Command failed with exit code " + exitCode);
+    }
+    return lines;
+  } catch (e) {
+    LOG.error("Error executing command '" + command + "': " + e.message);
+    return null;
+  }
+}
+
+// --- MAIN LOGIC ---
+
+// Get all the information
+var mangoVersion = getModuleVersion('core');
+var udmiVersion = getModuleVersion('udmi');
+var javaVersion = getSystemProperty('java.version');
+var osType = getSystemProperty('os.name');
+
+var osRelease = '';
+var osDistributor = '';
 
 //OS Type (Windows/Linux/etc.)
-if (os_type == 'Linux') {
-  var rt = Runtime.getRuntime();
+if (osType === 'Linux') {
+  var resultLines = runCommand('lsb_release -a');
+  if (resultLines) {
+    var osInfo = resultLines.reduce(function(acc, line) {
+      var parts = line.split(':', 2);
+      if (parts.length >= 2) {
+        var key = parts[0].trim();
+        var value = parts[1].trim();
+        acc[key] = value;
+      }
+      return acc;
+    }, {});
 
-  try {
-    runCommand('lsb_release -a');
-  } catch (err) {
-    LOG.debug(err.message);
+    osDistributor = osInfo['Distributor ID'] || '';
+    osRelease = osInfo['Release'] || '';
+  } else {
+    osDistributor = 'ERROR';
+    osRelease = 'ERROR';
   }
 }
 
-LOG.debug("OS Release: " + os_release);
-var_os_release.set(os_release);
+LOG.debug("OS Distributor: " + osDistributor);
+LOG.debug("OS Release: " + osRelease);
 
-LOG.debug("OS Distributor: " + os_distributor);
-var_os_distributor.set(os_distributor);
-
-function runCommand(commandString) {
-  LOG.debug('Executing command: ' + commandString);
-  var process = rt.exec(commandString);
-  var inputStreamReader = new InputStreamReader(process.getInputStream());
-  var bufferedReader = new BufferedReader(inputStreamReader);
-  var line;
-  while ((line = bufferedReader.readLine()) != null) {
-    var lineParts = line.split(':');
-    switch (lineParts[0].trim().toUpperCase()) {
-      case 'DISTRIBUTOR ID':
-        os_release = lineParts[1].trim();
-        break;
-      case 'RELEASE':
-        os_distributor = lineParts[1].trim();
-        break;
-      default:
-        continue;
-    }
-  }
-  var exitCode = process.waitFor();
-  return exitCode.toString();
-}
+// Set the context variables to the data points
+var_mango_version.set(mangoVersion);
+var_udmi_version.set(udmiVersion);
+var_java_version.set(javaVersion);
+var_os_type.set(osType);
+var_os_release.set(osRelease);
+var_os_distributor.set(osDistributor);


### PR DESCRIPTION
## Description

[RAD-5939](https://radixiot.atlassian.net/browse/RAD-5939)
Google Rews team needs to have a reliable and automatic way to track Modules version across all edge devices in all their sites.

**OS Details**
Data points needed:
- OS Type
- OS Release
- OS Distributor

**Java Details**
Data points needed:
- Java version

**Mango Details**
Data points needed:
- Mango Version
- UDMI Version

A/C

* Scripting Data Source that can be used on any mango v5 instance to capture information and store it in data point values
* Mango Core & UDMI module versions
* OS type information
* Java version

## Current behavior

- No Scripting Data Source with Mango, Modules and OS information

## Expected behavior

- Scripting Data Source with Mango, Modules and OS information

## Changes

* create script to populate a datapoints from a data source with the data from Mango, Modules and OS information

## Resources
<img width="1647" height="866" alt="Captura de pantalla 2025-09-25 a la(s) 1 18 52 p  m" src="https://github.com/user-attachments/assets/9ecbfc8a-2969-426b-b54b-43db0f0d80b4" />

<img width="1161" height="558" alt="Captura de pantalla 2025-09-25 a la(s) 1 03 26 p  m" src="https://github.com/user-attachments/assets/6dfe6583-a5f1-4cf3-811b-4087426e4da2" />

With Error
<img width="1193" height="510" alt="Captura de pantalla 2025-09-26 a la(s) 12 05 36 p  m" src="https://github.com/user-attachments/assets/707ff0ec-b129-48bf-bcb6-413efb43e033" />

## Tests

* Manual testing



[RAD-5939]: https://radixiot.atlassian.net/browse/RAD-5939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ