### PR TITLE
[RAD-6136] Script to Set Unreliable Data Points to Default Value

### DIFF
--- a/mango-javascript/set-unreliable-data-point-to-default-value.js
+++ b/mango-javascript/set-unreliable-data-point-to-default-value.js
@@ -21,66 +21,94 @@ const PointValueTime = Java.type('com.serotonin.m2m2.rt.dataImage.PointValueTime
 const NumericValue = Java.type('com.serotonin.m2m2.rt.dataImage.types.NumericValue');
 const DataType = Java.type('com.serotonin.m2m2.DataType');
 
-// Configuration
-const DEFAULT_NUMERIC_VALUE = new NumericValue(-1.0); // Default value to assign
-const MINIMUM_IDLE_TIME = 60_000; // 1 minute (in milliseconds)
+/**
+ * Called when the Mango event is raised.
+ * You must implement this method.
+ *
+ * @param event
+ */
+function eventRaised(event) {
+  // Configuration
+  const DEFAULT_NUMERIC_VALUE = new NumericValue(-1.0); // Default value to assign
+  const MINIMUM_IDLE_TIME = 60_000; // 1 minute (in milliseconds)
 
-// Get all the datasources
-const streamPoints = DataSourceRT.class.getDeclaredMethod("streamPoints");
-streamPoints.setAccessible(true);
+  // Get all the datasources
+  const streamPoints = DataSourceRT.class.getDeclaredMethod("streamPoints");
+  streamPoints.setAccessible(true);
 
-// Get running datasources
-const dsRTs = Common.runtimeManager.getRunningDataSources();
+  // Get running datasources
+  const dsRTs = Common.runtimeManager.getRunningDataSources();
 
-// Filter out persistent data sources (TCP/gRPC types)
-const dsRTList = [];
-dsRTs.forEach(function (dsRT) {
-  if(!(dsRT instanceof GrpcDatasourceRT || dsRT instanceof PersistentDataSourceRT)) {
-    dsRTList.push(dsRT);
-  }
-});
-
-//Now I have the data source on which I want to check the points
-dsRTList.forEach(function(element, index) {
-  const unreliablePointsList = [];
-  try {
-    // Get stream of data points from this data source
-    stream = streamPoints.invoke(element);
-
-    // Find points marked as "unreliable"
-    stream.collect(Collectors.toList()).forEach(function (dpRT) {
-      var attributeValue = dpRT.getAttribute(DataSourceRT.ATTR_UNRELIABLE_KEY);
-      if (attributeValue === true) {
-        console.log('Found unreliable point ' + dpRT.getVO().getXid());
-        unreliablePointsList.push(dpRT);
-      }
-    });
-  } catch (ex) {
-    print('Error while processing data source: ' + ex);
-  } finally {
-    stream && stream.close();
-  }
-
-  // Now process each unreliable point
-  unreliablePointsList.forEach(function(dataPointRT) {
-    var pointVO = dataPointRT.getVO();
-    var pointLocator = pointVO.getPointLocator();
-
-    // Only process numeric points
-    var isNumeric = pointLocator.getDataType() === DataType.NUMERIC;
-
-    // Check if the point has received a value update in the last minute
-    var recentValue = dataPointRT.getPointValueAfter(Common.timer.currentTimeMillis() - MINIMUM_IDLE_TIME);
-
-    if (isNumeric && !recentValue) {
-      // Set default value if no recent update
-      dataPointRT.setPointValue(
-          new PointValueTime(DEFAULT_NUMERIC_VALUE, Common.timer.currentTimeMillis()),
-          null // setPointSource is null for async update
-      );
-      console.log('Updated point: ' + pointVO.getXid());
-    } else {
-      console.log('Skipped point (recent or not numeric): ' + pointVO.getXid());
+  // Filter out persistent data sources (TCP/gRPC types)
+  const dsRTList = [];
+  dsRTs.forEach(function (dsRT) {
+    if(!(dsRT instanceof GrpcDatasourceRT || dsRT instanceof PersistentDataSourceRT)) {
+      dsRTList.push(dsRT);
     }
   });
-});
+
+  //Now I have the data source on which I want to check the points
+  dsRTList.forEach(function(element, index) {
+    const unreliablePointsList = [];
+    try {
+      // Get stream of data points from this data source
+      stream = streamPoints.invoke(element);
+
+      // Find points marked as "unreliable"
+      stream.collect(Collectors.toList()).forEach(function (dpRT) {
+        var attributeValue = dpRT.getAttribute(DataSourceRT.ATTR_UNRELIABLE_KEY);
+        if (attributeValue === true) {
+          console.log('Found unreliable point ' + dpRT.getVO().getXid());
+          unreliablePointsList.push(dpRT);
+        }
+      });
+    } catch (ex) {
+      print('Error while processing data source: ' + ex);
+    } finally {
+      stream && stream.close();
+    }
+
+    // Now process each unreliable point
+    unreliablePointsList.forEach(function(dataPointRT) {
+      var pointVO = dataPointRT.getVO();
+      var pointLocator = pointVO.getPointLocator();
+
+      // Only process numeric points
+      var isNumeric = pointLocator.getDataType() === DataType.NUMERIC;
+
+      // Check if the point has received a value update in the last minute
+      var recentValue = dataPointRT.getPointValueAfter(Common.timer.currentTimeMillis() - MINIMUM_IDLE_TIME);
+
+      if (isNumeric && !recentValue) {
+        // Set default value if no recent update
+        dataPointRT.setPointValue(
+            new PointValueTime(DEFAULT_NUMERIC_VALUE, Common.timer.currentTimeMillis()),
+            null // setPointSource is null for async update
+        );
+        console.log('Updated point: ' + pointVO.getXid());
+      } else {
+        console.log('Skipped point (recent or not numeric): ' + pointVO.getXid());
+      }
+    });
+  });
+}
+
+/**
+ * Called when the Mango event is acknowledged (the event may still be active).
+ * Supported as of Mango v4.0.0-beta.14, you are not required to implement this method.
+ *
+ * @param event
+ */
+function eventAcknowledged(event) {
+  //console.log('Acknowledged', event);
+}
+
+/**
+ * Called when the Mango event returns to normal or is deactivated (e.g. on shutdown).
+ * You must implement this method.
+ *
+ * @param event
+ */
+function eventInactive(event) {
+  //console.log('Inactive', event);
+}

--- a/mango-javascript/set-unreliable-data-point-to-default-value.js
+++ b/mango-javascript/set-unreliable-data-point-to-default-value.js
@@ -1,0 +1,86 @@
+/**
+ * Script to Set Unreliable Numeric Data Points to a Default Value
+ * Designed to run via Advanced Schedules using Graal.js
+ *
+ * Purpose:
+ * - Detect numeric data points marked as "unreliable"
+ * - Check if they haven't received an update for at least 1 minute
+ * - Set their value to a default (e.g. -1.0)
+ *
+ * Rules:
+ * - Skip points in Persistent TCP/gRPC data sources
+ * - Skip non-numeric data points
+ */
+
+const Common = Java.type('com.serotonin.m2m2.Common');
+const DataSourceRT = Java.type('com.serotonin.m2m2.rt.dataSource.DataSourceRT');
+const GrpcDatasourceRT = Java.type('com.radixiot.mango.persistent.datasource.GrpcDatasourceRT')
+const PersistentDataSourceRT = Java.type('com.serotonin.m2m2.persistent.ds.PersistentDataSourceRT')
+const Collectors = Java.type('java.util.stream.Collectors');
+const PointValueTime = Java.type('com.serotonin.m2m2.rt.dataImage.PointValueTime');
+const NumericValue = Java.type('com.serotonin.m2m2.rt.dataImage.types.NumericValue');
+const DataType = Java.type('com.serotonin.m2m2.DataType');
+
+// Configuration
+const DEFAULT_NUMERIC_VALUE = new NumericValue(-1.0); // Default value to assign
+const MINIMUM_IDLE_TIME = 60_000; // 1 minute (in milliseconds)
+
+// Get all the datasources
+const streamPoints = DataSourceRT.class.getDeclaredMethod("streamPoints");
+streamPoints.setAccessible(true);
+
+// Get running datasources
+const dsRTs = Common.runtimeManager.getRunningDataSources();
+
+// Filter out persistent data sources (TCP/gRPC types)
+const dsRTList = [];
+dsRTs.forEach(function (dsRT) {
+  if(!(dsRT instanceof GrpcDatasourceRT || dsRT instanceof PersistentDataSourceRT)) {
+    dsRTList.push(dsRT);
+  }
+});
+
+//Now I have the data source on which I want to check the points
+dsRTList.forEach(function(element, index) {
+  const unreliablePointsList = [];
+  try {
+    // Get stream of data points from this data source
+    stream = streamPoints.invoke(element);
+
+    // Find points marked as "unreliable"
+    stream.collect(Collectors.toList()).forEach(function (dpRT) {
+      var attributeValue = dpRT.getAttribute(DataSourceRT.ATTR_UNRELIABLE_KEY);
+      if (attributeValue === true) {
+        console.log('Found unreliable point ' + dpRT.getVO().getXid());
+        unreliablePointsList.push(dpRT);
+      }
+    });
+  } catch (ex) {
+    print('Error while processing data source: ' + ex);
+  } finally {
+    stream && stream.close();
+  }
+
+  // Now process each unreliable point
+  unreliablePointsList.forEach(function(dataPointRT) {
+    var pointVO = dataPointRT.getVO();
+    var pointLocator = pointVO.getPointLocator();
+
+    // Only process numeric points
+    var isNumeric = pointLocator.getDataType() === DataType.NUMERIC;
+
+    // Check if the point has received a value update in the last minute
+    var recentValue = dataPointRT.getPointValueAfter(Common.timer.currentTimeMillis() - MINIMUM_IDLE_TIME);
+
+    if (isNumeric && !recentValue) {
+      // Set default value if no recent update
+      dataPointRT.setPointValue(
+          new PointValueTime(DEFAULT_NUMERIC_VALUE, Common.timer.currentTimeMillis()),
+          null // setPointSource is null for async update
+      );
+      console.log('Updated point: ' + pointVO.getXid());
+    } else {
+      console.log('Skipped point (recent or not numeric): ' + pointVO.getXid());
+    }
+  });
+});


### PR DESCRIPTION
## Description

[RAD-6136](https://radixiot.atlassian.net/browse/RAD-6136)
This ticket will create a script that will identify Unreliable data points that meet certain criteria and set the value of those data points to a specific value.

A sample script for identifying all unreliable points is found here:
https://github.com/MangoAutomation/script-examples/blob/main/mango-javascript/unreliable-data-source.js

A rough example of how this can be done via a Gralljs script is here:
https://github.com/MangoAutomation/script-examples/tree/main/check-and-set-unreliable 

This script will:
* Be run on a schedule via Advanced Schedules
* Will not hold locks on data points in the runtime longer than necessary
* Will skip any data points that are:
  - In a Persistent TCP/gRPC data source
  - Not numeric data points

Identify:
* If a point is Running
* If a point is unreliable
* If the point has not received an updated value in a specific time period (at least 1 minute)
* Set the value of the numeric data point to the default value
  - This value will be stored in the TSDB database
  - This cannot change a data point from Unreliable to Reliable

## Current behavior

- No Scripting for Set Unreliable Data Points to Default Value

## Expected behavior

- Scripting for Set Unreliable Data Points to Default Value

## Changes

* create script to:
  - Detect numeric data points marked as "unreliable"
  - Check if they haven't received an update for at least 1 minute
  - Set their value to a default (e.g. -1.0)
  - With this rules:
    - Skip points in Persistent TCP/gRPC data sources
    - Skip non-numeric data points

## Resources
<img width="1628" height="545" alt="Captura de pantalla 2025-10-05 a la(s) 3 10 27 p  m" src="https://github.com/user-attachments/assets/9d8fc714-c5ef-4f3e-9bf3-462bad876302" />

<img width="1123" height="189" alt="Captura de pantalla 2025-10-05 a la(s) 3 13 33 p  m" src="https://github.com/user-attachments/assets/50346663-fdd1-40bc-90c1-e0ad018a6c4d" />

Pass one minute:

<img width="1125" height="213" alt="Captura de pantalla 2025-10-05 a la(s) 3 13 23 p  m" src="https://github.com/user-attachments/assets/f28c9bbf-5a37-4ed6-8abe-072d5a72df27" />

<img width="1635" height="510" alt="Captura de pantalla 2025-10-05 a la(s) 3 12 24 p  m" src="https://github.com/user-attachments/assets/4007d372-0e00-4b01-a18d-90fd18b99c84" />




## Tests

* Manual testing



[RAD-6136]: https://radixiot.atlassian.net/browse/RAD-6136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ