### PR TITLE
[RAD-6136] Script to Set Unreliable Data Points to Default Value Fix

### DIFF
--- a/mango-javascript/set-unreliable-data-point-to-default-value.js
+++ b/mango-javascript/set-unreliable-data-point-to-default-value.js
@@ -31,13 +31,15 @@ function eventRaised(event) {
   // Configuration
   const DEFAULT_NUMERIC_VALUE = new NumericValue(-1.0); // Default value to assign
   const MINIMUM_IDLE_TIME = 60_000; // 1 minute (in milliseconds)
+  const DS_XIDS = ['DS_XID1','DS_XID2','DS_XID3']; // list of datasource's
 
   // Get all the datasources
   const streamPoints = DataSourceRT.class.getDeclaredMethod("streamPoints");
   streamPoints.setAccessible(true);
 
   // Get running datasources
-  const dsRTs = Common.runtimeManager.getRunningDataSources();
+  const dsList = Array.from(Common.runtimeManager.getRunningDataSources());
+  const dsRTs = dsList.filter(ds => DS_XIDS.includes(ds.getVo().getXid()));
 
   // Filter out persistent data sources (TCP/gRPC types)
   const dsRTList = [];


### PR DESCRIPTION
## Description

[RAD-6136](https://radixiot.atlassian.net/browse/RAD-6136)
This ticket will create a script that will identify Unreliable data points that meet certain criteria and set the value of those data points to a specific value.
Previous PR: https://github.com/MangoAutomation/script-examples/pull/26

Add list of datasource XIDs 

## Current behavior

- Get all running datasources

## Expected behavior

- Use the list of datasource XIDs 

## Changes

* Add filter for the list of datasource XIDs 

## Resources

## Tests

* Manual testing


[RAD-6136]: https://radixiot.atlassian.net/browse/RAD-6136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ